### PR TITLE
4.1.12: 修复Cookie适配高版本Android系统（针对X5内核），修复type=file的input标签在高版本系统异常问题

### DIFF
--- a/Engine/src/main/java/org/zywx/wbpalmstar/base/BConstant.java
+++ b/Engine/src/main/java/org/zywx/wbpalmstar/base/BConstant.java
@@ -25,8 +25,8 @@ import java.text.DecimalFormat;
 
 public class BConstant {
 
-    public static final String ENGINE_VERSION="4.1.11";
-    public static final int ENGINE_VERSION_CODE=41011;
+    public static final String ENGINE_VERSION="4.1.12";
+    public static final int ENGINE_VERSION_CODE=41012;
 
     public static final String F_URL = "url";
     public static final String F_WIDGET = "widget";

--- a/Engine/src/main/java/org/zywx/wbpalmstar/base/BConstant.java
+++ b/Engine/src/main/java/org/zywx/wbpalmstar/base/BConstant.java
@@ -25,8 +25,8 @@ import java.text.DecimalFormat;
 
 public class BConstant {
 
-    public static final String ENGINE_VERSION="4.1.10";
-    public static final int ENGINE_VERSION_CODE=41010;
+    public static final String ENGINE_VERSION="4.1.11";
+    public static final int ENGINE_VERSION_CODE=41011;
 
     public static final String F_URL = "url";
     public static final String F_WIDGET = "widget";

--- a/Engine/src/system/java/org/zywx/wbpalmstar/base/WebViewSdkCompat.java
+++ b/Engine/src/system/java/org/zywx/wbpalmstar/base/WebViewSdkCompat.java
@@ -29,7 +29,11 @@ public class WebViewSdkCompat {
 
     public static void setCookie(String inUrl, String cookie){
         CookieManager.getInstance().setCookie(inUrl, cookie);
-        CookieSyncManager.getInstance().sync();
+        if (Build.VERSION.SDK_INT < 21) {
+            CookieSyncManager.getInstance().sync();
+        } else {
+            CookieManager.getInstance().flush();
+        }
     }
 
     public static  String getCookie(String inUrl){

--- a/Engine/src/system/java/org/zywx/wbpalmstar/engine/CBrowserMainFrame.java
+++ b/Engine/src/system/java/org/zywx/wbpalmstar/engine/CBrowserMainFrame.java
@@ -168,7 +168,7 @@ public class CBrowserMainFrame extends WebChromeClient {
         ((EBrowserActivity) mContext).setmUploadMessage(getCompatCallback(uploadMsg));
         Intent i = new Intent(Intent.ACTION_GET_CONTENT);
         i.addCategory(Intent.CATEGORY_OPENABLE);
-        i.setType("image/*");
+        i.setType("*/*");
         ((EBrowserActivity) mContext).startActivityForResult(Intent.createChooser(i, "File Chooser"),
                 EBrowserActivity.FILECHOOSER_RESULTCODE);
     }
@@ -188,7 +188,7 @@ public class CBrowserMainFrame extends WebChromeClient {
         ((EBrowserActivity) mContext).setmUploadMessage(getCompatCallback(uploadMsg));
         Intent i = new Intent(Intent.ACTION_GET_CONTENT);
         i.addCategory(Intent.CATEGORY_OPENABLE);
-        i.setType("image/*");
+        i.setType("*/*");
         ((EBrowserActivity) mContext).startActivityForResult(Intent.createChooser(i, "File Chooser"),
                 EBrowserActivity.FILECHOOSER_RESULTCODE);
     }

--- a/Engine/src/x5/java/org/zywx/wbpalmstar/base/WebViewSdkCompat.java
+++ b/Engine/src/x5/java/org/zywx/wbpalmstar/base/WebViewSdkCompat.java
@@ -2,6 +2,7 @@ package org.zywx.wbpalmstar.base;
 
 import android.app.Activity;
 import android.content.Context;
+import android.os.Build;
 
 import com.tencent.smtt.export.external.interfaces.IX5WebChromeClient;
 import com.tencent.smtt.sdk.CookieManager;
@@ -75,7 +76,11 @@ public class WebViewSdkCompat {
 
     public static void setCookie(String inUrl, String cookie) {
         CookieManager.getInstance().setCookie(inUrl, cookie);
-        CookieSyncManager.getInstance().sync();
+        if (Build.VERSION.SDK_INT < 21) {
+            CookieSyncManager.getInstance().sync();
+        } else {
+            CookieManager.getInstance().flush();
+        }
     }
     public static void clearCookie() {
         CookieManager.getInstance().removeAllCookie();

--- a/Engine/src/x5/java/org/zywx/wbpalmstar/engine/CBrowserMainFrame.java
+++ b/Engine/src/x5/java/org/zywx/wbpalmstar/engine/CBrowserMainFrame.java
@@ -170,7 +170,7 @@ public class CBrowserMainFrame extends WebChromeClient {
         ((EBrowserActivity) mContext).setmUploadMessage(getCompatCallback(uploadMsg));
         Intent i = new Intent(Intent.ACTION_GET_CONTENT);
         i.addCategory(Intent.CATEGORY_OPENABLE);
-        i.setType("image/*");
+        i.setType("*/*");
         ((EBrowserActivity) mContext).startActivityForResult(Intent.createChooser(i, "File Chooser"),
                 EBrowserActivity.FILECHOOSER_RESULTCODE);
     }
@@ -190,7 +190,7 @@ public class CBrowserMainFrame extends WebChromeClient {
         ((EBrowserActivity) mContext).setmUploadMessage(getCompatCallback(uploadMsg));
         Intent i = new Intent(Intent.ACTION_GET_CONTENT);
         i.addCategory(Intent.CATEGORY_OPENABLE);
-        i.setType("image/*");
+        i.setType("*/*");
         ((EBrowserActivity) mContext).startActivityForResult(Intent.createChooser(i, "File Chooser"),
                 EBrowserActivity.FILECHOOSER_RESULTCODE);
     }

--- a/en_baseEngineProject/androidEngine.xml
+++ b/en_baseEngineProject/androidEngine.xml
@@ -3,6 +3,6 @@
     <version>$version$</version>
     <package>$package$</package>
     <kernel>$kernel$</kernel>
-    <description>同步调用onApplicationCreate方法;修复三方启动提示程序不完整的问题</description>
+    <description>修复input标签type为file时选择文件在有些高版本系统中的异常问题</description>
     <dssVersion>4.0.0</dssVersion>
 </info>

--- a/en_baseEngineProject/androidEngine.xml
+++ b/en_baseEngineProject/androidEngine.xml
@@ -3,6 +3,6 @@
     <version>$version$</version>
     <package>$package$</package>
     <kernel>$kernel$</kernel>
-    <description>修复input标签type为file时选择文件在有些高版本系统中的异常问题</description>
+    <description>修复Cookie设置在5.1系统以上可能会无效的问题（主要针对X5内核）；修复input标签type为file时选择文件在有些高版本系统中的异常问题</description>
     <dssVersion>4.0.0</dssVersion>
 </info>


### PR DESCRIPTION
4.1.12: 修复Cookie适配高版本Android系统（针对X5内核），修复type=file的input标签在高版本系统异常问题